### PR TITLE
[전시원] Feat: 피드백 반영 및 뉴스 자동 롤링 영역 기본 틀 구현

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,26 @@
       </div>
       <div class="date" id="current-date"></div>
     </header>
+    <section class="auto-rolling-news-bar">
+      <div class="auto-rolling-news">
+        <ul class="news-1-contents">
+          <li>헤드라인 1</li>
+          <li>헤드라인 2</li>
+          <li>헤드라인 3</li>
+          <li>헤드라인 4</li>
+          <li>헤드라인 5</li>
+        </ul>
+      </div>
+      <div class="auto-rolling-news">
+        <ul class="news-2-contents">
+          <li>헤드라인 1</li>
+          <li>헤드라인 2</li>
+          <li>헤드라인 3</li>
+          <li>헤드라인 4</li>
+          <li>헤드라인 5</li>
+        </ul>
+      </div>
+    </section>
     <script type="module" src="src/js/app.js"></script>
   </body>
 </html>

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -33,3 +33,41 @@ header {
   font-weight: 500;
   line-height: 22px;
 }
+
+.auto-rolling-news-bar {
+  display: flex;
+  margin: 0 auto;
+  width: 930px;
+  height: 49px;
+  justify-content: space-between;
+}
+
+.auto-rolling-news {
+  display: flex;
+  width: 461px;
+  height: 49px;
+  background-color: #f5f7f9;
+  border: 1px solid #d2dae0;
+  overflow: hidden;
+  flex-direction: column;
+}
+
+.news-1-contents {
+  position: relative;
+  list-style-type: none;
+  width: 100px;
+}
+
+.news-1-contents li {
+  height: 51px;
+}
+
+.news-2-contents {
+  position: relative;
+  list-style-type: none;
+  width: 100px;
+}
+
+.news-2-contents li {
+  height: 51px;
+}

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1,7 +1,7 @@
 header {
-  width: 1307px;
+  width: 930px;
   height: 104px;
-  margin: 4% auto;
+  margin: 4px auto;
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1,6 +1,3 @@
 import { getFormattedDate } from "./utils/dateUtils.js";
 
-// DOMContentLoaded 이벤트 발생 시 날짜를 설정
-document.addEventListener("DOMContentLoaded", () => {
-  document.getElementById("current-date").textContent = getFormattedDate();
-});
+document.getElementById("current-date").textContent = getFormattedDate();

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1,3 +1,8 @@
 import { getFormattedDate } from "./utils/dateUtils.js";
+import { createRoller } from "./utils/rollerUtils.js";
 
 document.getElementById("current-date").textContent = getFormattedDate();
+createRoller(".news-1-contents");
+setTimeout(() => {
+  createRoller(".news-2-contents");
+}, 1000);

--- a/src/js/utils/rollerUtils.js
+++ b/src/js/utils/rollerUtils.js
@@ -1,0 +1,131 @@
+export function createRoller(rollerSelector) {
+  const newsContainer = document.querySelector(rollerSelector).parentElement;
+  const roller = newsContainer.querySelector("ul");
+  const rollerItems = roller.querySelectorAll("li");
+
+  const height = newsContainer.offsetHeight;
+  const num = rollerItems.length;
+  const max = height * num;
+  let move = 0;
+  let currentRoller = roller;
+
+  let cloneRollerInterval;
+  let newsRollerInterval;
+  let lastPausedTime = 0;
+
+  // 초기 설정
+  roller.style.transition = "none";
+  roller.style.top = "0";
+
+  // 롤러 복제
+  function cloneRoller() {
+    const clone = currentRoller.cloneNode(true);
+    clone.style.top = "0px";
+    newsContainer.appendChild(clone);
+    console.log(`[${rollerSelector}] 롤러 복제`);
+    return clone;
+  }
+
+  function newsRoller() {
+    console.log(
+      `[${rollerSelector}] newsRoller 함수 호출. 현재 move: ${move}, top: ${currentRoller.style.top}`
+    );
+    move += height;
+
+    // 원본 롤러가 모두 올라갔을 때
+    if (move >= max) {
+      currentRoller.style.transition = "none";
+      currentRoller.style.top = "0";
+      move = 0;
+      console.log(`[${rollerSelector}] 롤러가 최대로 올라가서 초기화`);
+
+      // 원본 롤러 삭제
+      if (newsContainer.contains(currentRoller)) {
+        newsContainer.removeChild(currentRoller);
+        console.log(`[${rollerSelector}] 원본 롤러 삭제`);
+      }
+
+      // 복제된 롤러 추가 및 롤링 시작
+      currentRoller = cloneRoller();
+      startRolling(currentRoller);
+    } else {
+      currentRoller.style.transition = "top 0.6s";
+      currentRoller.style.top = `-${move}px`;
+      console.log(
+        `[${rollerSelector}] 새로운 top 값: ${currentRoller.style.top}`
+      );
+    }
+  }
+
+  // 새로운 롤러에서 롤링 시작
+  function startRolling(clone) {
+    let cloneMove = 0;
+
+    function cloneRollerAnimation() {
+      console.log(
+        `[${rollerSelector}] cloneRollerAnimation 함수 호출. 현재 cloneMove: ${cloneMove}, clone의 top 값: ${clone.style.top}`
+      );
+      cloneMove += height;
+
+      if (cloneMove >= max) {
+        clone.style.transition = "none";
+        clone.style.top = "0";
+        cloneMove = 0;
+
+        if (newsContainer.contains(clone)) {
+          newsContainer.removeChild(clone);
+          console.log(`[${rollerSelector}] 복제 롤러 삭제`);
+        }
+      } else {
+        clone.style.transition = "top 0.6s";
+        clone.style.top = `-${cloneMove}px`;
+        console.log(`[${rollerSelector}] 새로운 top 값: ${clone.style.top}`);
+      }
+    }
+
+    cloneRollerInterval = setInterval(cloneRollerAnimation, 5000);
+  }
+
+  // 원본 롤러에서 롤링 시작
+  startRolling(roller);
+
+  // 복제된 롤러가 롤링을 이어가도록
+  newsRollerInterval = setInterval(newsRoller, 5000);
+
+  // // 마우스 호버 이벤트
+  // rollerItems.forEach((item) => {
+  //   item.addEventListener("mouseenter", () => {
+  //     console.log(`[${rollerSelector}] mouseenter`);
+  //     clearInterval(newsRollerInterval);
+  //     clearInterval(cloneRollerInterval);
+  //     lastPausedTime = Date.now();
+  //     item.classList.add("underline");
+  //   });
+
+  //   item.addEventListener("mouseleave", () => {
+  //     const elapsedTime = Date.now() - lastPausedTime;
+  //     const remainingTime = 5000 - (elapsedTime % 5000);
+
+  //     console.log(
+  //       `[${rollerSelector}] mouseleave. 남은 시간: ${remainingTime}ms`
+  //     );
+
+  //     setTimeout(() => {
+  //       newsRollerInterval = setInterval(newsRoller, 5000);
+  //       cloneRollerInterval = setInterval(() => {
+  //         startRolling(currentRoller);
+  //       }, 5000);
+  //     }, remainingTime);
+
+  //     item.classList.remove("underline");
+  //   });
+  // });
+
+  const style = document.createElement("style");
+  style.innerHTML = `
+    .underline {
+      text-decoration: underline;
+    }
+  `;
+  document.head.appendChild(style);
+}


### PR DESCRIPTION
## 🖥️ Preview
https://github.com/user-attachments/assets/613cfc6b-b755-4055-b79d-798d9a38a549

## 💡 Feature
- [x] 뉴스 자동 롤링 영역 기본 틀 구현
- [x] 뉴스 자동 롤링 애니메이션 구현

## ❓ 고민한 점
- 무한 롤링을 구현하는 방법을 고민 -> 원본 롤러가 모두 올라가면 복제 롤러를 그 아래에 붙이고 원본 롤러는 삭제하는 방식(반복)으로 구현 
- 마우스 호버 이벤트 구현 중 애니메이션이 꼬이는 문제가 발생하여 해결 중 ..

## 📗 참고 자료
[제이쿼리를 이용해 공지사항 롤링을 만들어보자](https://blog.naver.com/ddo_gun/220815915190)
[이번에야말로 CSS Flex를 익혀보자](https://studiomeal.com/archives/197)
[[Javascript] 자동 롤링 배너를 만들어보자!](https://velog.io/@seoyaon/Javascript-%EC%9E%90%EB%8F%99-%EB%A1%A4%EB%A7%81-%EB%B0%B0%EB%84%88-%EB%A7%8C%EB%93%A4%EA%B8%B0)
[[JS] 자바스크립트 타이머 함수](https://ziszini.tistory.com/26)
[setInterval / clearInterval 을 이용한 함수 반복 중단, 재시작](https://velog.io/@effort_jk/setInterval-clearInterval-%EC%9D%84-%EC%9D%B4%EC%9A%A9%ED%95%9C-%ED%95%A8%EC%88%98-%EB%B0%98%EB%B3%B5-%EC%A4%91%EB%8B%A8-%EC%9E%AC%EC%8B%9C%EC%9E%91)