### PR TITLE
[정예린] Feat: 뉴스 자동 롤링 애니메이션 구현

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,10 @@
             <div id="header-right"></div>
         </header>
 
-        <div id="rollingBar"></div>
+        <div id="rollingBar">
+            <div id="rollingBar-left"></div>
+            <div id="rollingBar-right"></div>
+        </div>
 
         <div id="newsSection">
             <!-- <div id="allMedia">전체 언론사</div>

--- a/index.html
+++ b/index.html
@@ -14,8 +14,16 @@
         </header>
 
         <div id="rollingBar">
-            <div id="rollingBar-left"></div>
-            <div id="rollingBar-right"></div>
+            <div id="rollingBar-left">
+                <ul>
+
+                </ul>
+            </div>
+            <div id="rollingBar-right">
+                <ul>
+
+                </ul>
+            </div>
         </div>
 
         <div id="newsSection">

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -1,6 +1,6 @@
 import { getDate } from "../utils/getDate.js";
 export function header() {
-    console.log("Header function is being executed"); // header.js에서 오류나서 콘솔 추가
+    console.log("Header function is being executed");
 
 
     const leftSection = document.getElementById("header-left");

--- a/src/components/rolling.js
+++ b/src/components/rolling.js
@@ -1,0 +1,48 @@
+export function AutoRollingNews(articlesLeft, articlesRight) {
+    const rollingBarLeft = document.querySelector('#rollingBar-left ul');
+    const rollingBarRight = document.querySelector('#rollingBar-right ul');
+
+    articlesLeft.forEach(article => {
+        const li = document.createElement('li');
+        li.textContent = article;
+        rollingBarLeft.appendChild(li);
+    });
+
+    articlesRight.forEach(article => {
+        const li = document.createElement('li');
+        li.textContent = article;
+        rollingBarRight.appendChild(li);
+    });
+
+    let currentIndexLeft = 0;
+    let currentIndexRight = 0;
+
+    function showNextArticle(rollingBar, currentIndex, displayTime) {
+        const items = rollingBar.children;
+        if (items.length > 0) {
+            // 현재 항목을 보이게 하고, 다음 인덱스로 넘어감
+            items[currentIndex].classList.add('visible'); // 보이게 설정
+
+            // 대기 시간 후 사라지도록 설정
+            setTimeout(() => {
+                items[currentIndex].classList.add('roll');
+                
+                // 0.3초 후에 항목 안 보이게 함
+                setTimeout(() => {
+                    items[currentIndex].classList.remove('visible'); // 안보이게 설정
+                    items[currentIndex].classList.remove('roll'); // 롤링 효과 제거
+                    currentIndex = (currentIndex + 1) % items.length; // 다음 항목
+
+                    // 다음 항목을 보여줌 = 재귀 호출
+                    showNextArticle(rollingBar, currentIndex, displayTime);
+                }, 300); // 롤링 효과가 끝난 후 0.3초동안 대기 
+            }, displayTime);
+        }
+    }
+
+
+    showNextArticle(rollingBarLeft, currentIndexLeft, 5000);
+    setTimeout(() => {
+        showNextArticle(rollingBarRight, currentIndexRight, 5000); // 오른쪽은 1초 후에 시작하게 하여 차이를 둠
+    }, 1000);
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,22 @@
 import { header } from "./components/header.js"
+import { AutoRollingNews } from "./components/rolling.js";
 
 header(); // 의미없는 renderHeader 삭제
+
+const leftArticles = [
+    "기사 제목 1", 
+    "기사 제목 2", 
+    "기사 제목 3", 
+    "기사 제목 4", 
+    "기사 제목 5"
+];
+
+const rightArticles = [
+    "기사 제목 6", 
+    "기사 제목 7", 
+    "기사 제목 8", 
+    "기사 제목 9", 
+    "기사 제목 10"
+];
+
+AutoRollingNews(leftArticles, rightArticles);

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,3 @@
 import { header } from "./components/header.js"
 
-export function renderHeader(){
-    header();
-}
-
-renderHeader();
+header(); // 의미없는 renderHeader 삭제

--- a/src/styles/header.css
+++ b/src/styles/header.css
@@ -11,8 +11,7 @@
 
 #header-left {
     display: flex;
-    margin-left: 175px;
-    align-items: center;
+    align-items: center; /*margin-left: 175px; 없앰*/
     width: 50%;
     height: 29px;
 }

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -2,15 +2,35 @@
 body {
     margin: 0;
     padding: 0;
+    margin-left: 175px; /*postion: absolute 없애고, body에서 margin-left 지정, 얘 없애면 헤더까지 같이 움직임..왜지?*/
 }
 
 #rollingBar {
-    width: 930px;
+    /* width: 930px;
     height: 49px;
     top: 127px;
     left: 175px;
-    background-color: #f0f0f0;
+    background-color: #fff;
     position: absolute;
+
+    display: flex;
+    justify-content: space-between;
+    gap: 8px; */
+    width: 930px;
+    height: 49px;
+    margin-bottom: 39px;
+    display: flex;
+    background-color: #fff;
+    justify-content: space-between;
+    gap: 8px;
+}
+
+
+#rollingBar-left, #rollingBar-right {
+    width: calc(50% - 4px);
+    background-color: #f0f0f0;
+    height: 100%;
+    border: 1px solid var(--border-border-default, #D2DAE0)
 }
 
 #newsSection {
@@ -18,16 +38,13 @@ body {
     height: 24px;
     background-color: beige;
     top: 208px;
-    gap: 0px; 
-    left: 175px;
-    position: absolute;
+    gap: 0px;
 }
 
 #gridView {
     width: 930px;
     height: 388px;
     top: 256px;
-    left: 175px;
     border: 1px solid #ccc;
     position: absolute;
     display: grid;

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -2,20 +2,10 @@
 body {
     margin: 0;
     padding: 0;
-    margin-left: 175px; /*postion: absolute 없애고, body에서 margin-left 지정, 얘 없애면 헤더까지 같이 움직임..왜지?*/
+    margin-left: 175px;
 }
 
 #rollingBar {
-    /* width: 930px;
-    height: 49px;
-    top: 127px;
-    left: 175px;
-    background-color: #fff;
-    position: absolute;
-
-    display: flex;
-    justify-content: space-between;
-    gap: 8px; */
     width: 930px;
     height: 49px;
     margin-bottom: 39px;
@@ -23,15 +13,81 @@ body {
     background-color: #fff;
     justify-content: space-between;
     gap: 8px;
+    overflow: hidden;
+    display: flex;
 }
 
-
 #rollingBar-left, #rollingBar-right {
+    display: flex;
+    justify-content: center;
+    align-items: center; 
     width: calc(50% - 4px);
     background-color: #f0f0f0;
     height: 100%;
     border: 1px solid var(--border-border-default, #D2DAE0)
 }
+
+#rollingBar-left ul,
+#rollingBar-right ul {
+    list-style-type: none;
+    padding: 0;
+    margin: 0;
+    width: 95%;
+    height: 50%;
+    display: flex;
+
+    position: relative;
+    overflow: hidden;
+}
+
+
+#rollingBar-left li,
+#rollingBar-right li {
+    position: absolute; 
+    opacity: 0; /* 안 보일 때 */
+    transition: opacity 1s ease, transform 1s ease;
+}
+
+#rollingBar-left li.visible,
+#rollingBar-right li.visible {
+    opacity: 1; /* 보일 때 */
+    transform: translateY(0);
+    animation: rollUp 0.3s forwards; 
+}
+
+#rollingBar-left li.roll,
+#rollingBar-right li.roll {
+    transform: translateY(-100%); /* 위로 롤링 */
+    opacity: 0;
+    animation: rollOut 0.3s forwards;
+}
+
+
+@keyframes rollUp {
+    from {
+        transform: translateY(100%); /* 아래->위 */
+        opacity: 0;
+    }
+    to {
+        transform: translateY(0);
+        opacity: 1;
+    }
+}
+
+@keyframes rollOut {
+    from {
+        transform: translateY(0);
+        opacity: 1;
+    }
+    to {
+        transform: translateY(-100%); /* 위로 사라짐 */
+        opacity: 0;
+    }
+}
+
+
+
+
 
 #newsSection {
     width: 930px;


### PR DESCRIPTION
## 🖥️ Preview

https://github.com/user-attachments/assets/bfd79729-3c89-4114-9e73-650b9c36d726



## 💡 Feature
- [x] 뉴스 자동 롤링바 애니메이션
- [x] 피드백 반영(absolute, 의미 없는 함수 지양)

## ❓ 고민한 점
(고민 -> 시도 -> 해결)
- 현재 항목이 점점 사라지고, 다음 항목이 밑에서 위로 올라오는 애니메이션 효과를 어떻게 구현할지 고민 -> css 애니메이션으로 rollup과 rollout으로 각각 효과를 지정했다.
- 롤링바의 왼쪽과 오른쪽이 1초 차이가 나야함 -> 오른쪽의 롤링바에 1초 대기시간을 주어 구현은 했지만, 웹페이지 실행했을 때 맨처음 1초동안 오른쪽 롤링바엔 아무것도 뜨지 않아 수정이 필요하다..

- 롤링바 호버는 오류나서 아직 구현하는 중이다.

## 📗 참고 자료
(고민 해결 과정에서 참고한 자료)
자동 롤링: 
- https://uiweb.tistory.com/120
- https://imivory.tistory.com/entry/javascript%EC%9E%90%EB%8F%99%EB%A1%A4%EB%A7%81%EB%90%98%EB%8A%94-%EC%8B%A4%EC%8B%9C%EA%B0%84%EA%B2%80%EC%83%89%EC%96%B4-%EB%A7%8C%EB%93%A4%EA%B8%B0