### PR TITLE
[이기탁] Feat: 최신 뉴스 헤드라인 레이아웃 추가

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,12 +1,15 @@
 import Header from './components/Header.js';
 import List from './components/List.js';
+import HeadLine from './components/HeadLIne.js';
 import createComponent from './core/component.js';
 function App() {
     const headerComponent = createComponent(Header);
+    const headLineComponent = createComponent(HeadLine);
     const listComponent = createComponent(List);
     return {
         element: `
         ${headerComponent.element}
+        ${headLineComponent.element}
         ${listComponent.element}
         `,
     };

--- a/src/components/HeadLine.js
+++ b/src/components/HeadLine.js
@@ -1,0 +1,25 @@
+function HeadLine() {
+    const newHeadLine1 = [
+        "연합뉴스",
+        "공공의료기관 의사 3천500여명 부족…연봉 6억여원까지 치솟아"
+    ]
+    const newHeadLine2 = [
+        "연합뉴스",
+        "의대교수들 \"국민 상해입히는 급발진 정부…의평원 말살하려 해\""
+    ]
+    return {
+        element: `
+            <article>
+                <div>
+                <h1>${newHeadLine1[0]}</h1>
+                <h2>${newHeadLine1[1]}</h2>
+                </div>
+                <div>
+                <h1>${newHeadLine2[0]}</h1>
+                <h2>${newHeadLine2[1]}</h2>
+                </div>
+            </article>
+        `
+    };
+}
+export default HeadLine;

--- a/src/styles/headLine.css
+++ b/src/styles/headLine.css
@@ -1,0 +1,46 @@
+article {
+    width: 800px;
+    height: 40px;
+    display: flex;
+    flex-direction: row;
+    gap: 5px;
+    justify-content: center;
+    align-items: center;
+
+    div {
+        width: 390px;
+        height: 32px;
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        padding-left: 10px;
+        font-family: sans-serif;
+        border: 1px solid rgb(212, 217, 222);
+        background-color: rgb(247, 247, 249);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        cursor: pointer;
+    }
+
+    h1 {
+        width: 50px;
+        height: auto;
+        font-size: 11px;
+        font-weight: 600;
+    }
+
+    h2 {
+        width: 330px;
+        height: auto;
+        font-size: 10px;
+        font-weight: 400;
+        color: rgb(82, 89, 102);
+    }
+
+    :hover {
+        h2 {
+            text-decoration: underline;
+        }
+    }
+}

--- a/src/styles/list.css
+++ b/src/styles/list.css
@@ -16,8 +16,8 @@
       justify-content: flex-start;
       align-items: center;
       font-family: sans-serif;
-      border: 1px solid gray;
-      background-color: whitesmoke;
+      border: 1px solid rgb(212, 217, 222);
+      background-color: rgb(247, 247, 249);
       color: gray;
       text-align: center;
       gap: 10px;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,5 +1,6 @@
 @import url("header.css");
 @import url("list.css");
+@import url("headLine.css");
 
 #app {
     width: 100vw;
@@ -10,6 +11,7 @@
     flex-direction: column;
     justify-content: center;
     align-items: center;
+    gap: 10px;
 }
 
 body {


### PR DESCRIPTION
## 🖥️ Preview
<img width="925" alt="image" src="https://github.com/user-attachments/assets/612d1b43-bdb8-4b71-826c-198905c2a78e">

## 💡 Feature
- 최신 뉴스 헤드라인 레이아웃 작성 

## ❓ 고민한 점
(고민 -> 시도 -> 해결)
- 헤드라인 뉴스 데이터 끌어올 때 json을 써야할 거 같은데.. 이건 다음번에..
- 무한롤링 애니메이션도 해야하는데.. 이건 다음번에..
## 📗 참고 자료
(고민 해결 과정에서 참고한 자료)